### PR TITLE
Fix for issue #129 undefined filter references

### DIFF
--- a/__tests__/lib/evaluator/Evaluator.test.js
+++ b/__tests__/lib/evaluator/Evaluator.test.js
@@ -110,6 +110,11 @@ describe('Evaluator', () => {
       context.foo.baz.bar
     )
   })
+  it('it does not throw an error when a field is selected on an undefined object', async () => {
+    const context = { foo: { baz: { bar: 'tek' } } }
+    const e = new Evaluator(grammar, context)
+    return expect(e.eval(toTree('fook["bar"]'))).resolves.toBe(undefined)
+  })
   it('throws when transform does not exist', async () => {
     const e = new Evaluator(grammar)
     return expect(e.eval(toTree('"hello"|world'))).rejects.toThrow(Error)

--- a/lib/evaluator/Evaluator.js
+++ b/lib/evaluator/Evaluator.js
@@ -145,6 +145,9 @@ class Evaluator {
    */
   _filterStatic(subject, expr) {
     return this.eval(expr).then((res) => {
+      if (subject === undefined || subject === null) {
+        return undefined
+      }
       if (typeof res === 'boolean') {
         return res ? subject : undefined
       }


### PR DESCRIPTION
This PR fixes the issue #129 initially posted in Tom Frost's repo.  When an filter expression is used as a field on an undefined subject, an exception is thrown.  This branch adds a test for this and adds a check for an undefined subject prior to attempting to resolve the reference.
